### PR TITLE
fix(ci): remove untrusted PR trigger from markdown link checker

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,8 +1,6 @@
 name: Markdown Links Check
 # runs every monday at 9 am
 on:
-  pull_request:
-    branches: ["**"]
   schedule:
     - cron: "0 9 * * 1"
   workflow_dispatch: null


### PR DESCRIPTION
### Motivation
- The markdown link-check workflow ran on `pull_request`, allowing untrusted PR content to cause outbound HTTP requests from GitHub runners and introducing an SSRF/egress risk.
- The goal is to stop automatic checks on untrusted PR content while keeping scheduled and manual checks available.

### Description
- Removed the `on.pull_request` trigger from `.github/workflows/links.yml`.
- Preserved the `schedule` and `workflow_dispatch` triggers, `permissions: {}`, and the existing job steps and configuration for the link-checker.

### Testing
- Displayed the updated workflow with `sed -n '1,220p' .github/workflows/links.yml` and confirmed the `pull_request` section is gone; the command completed successfully.
- Inspected the file with `nl -ba .github/workflows/links.yml | sed -n '1,80p'` and confirmed only `schedule` and `workflow_dispatch` triggers remain; the command completed successfully.
- Applied the patch to `.github/workflows/links.yml` using the repo tooling and received a successful update result.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f605680ee48330b1380b5dff7cfca4)