### PR TITLE
fix(post): harden YouTube iframe embed in dev workflow post

### DIFF
--- a/blog/posts/2025-07-24-dev-workflow.md
+++ b/blog/posts/2025-07-24-dev-workflow.md
@@ -73,8 +73,11 @@ that does a post-morten on the whole thing:
 </style>
 <div class="embed-container">
   <iframe
-    src="https://www.youtube.com/embed/CqKZhYsjw6M"
+    src="https://www.youtube-nocookie.com/embed/CqKZhYsjw6M"
+    title="YouTube video player"
     frameborder="0"
+    referrerpolicy="strict-origin-when-cross-origin"
+    sandbox="allow-scripts allow-same-origin allow-presentation"
     allowfullscreen
   ></iframe>
 </div>


### PR DESCRIPTION
### Motivation
- Remediate a medium-severity privacy/exposure issue where a blog post embedded an unsandboxed YouTube iframe that could load third-party JavaScript/cookies and leak referrer data.

### Description
- Updated `blog/posts/2025-07-24-dev-workflow.md` to use the privacy-enhanced host and add iframe controls: changed `src` to `https://www.youtube-nocookie.com/embed/CqKZhYsjw6M`, added `title`, `referrerpolicy="strict-origin-when-cross-origin"`, and `sandbox="allow-scripts allow-same-origin allow-presentation"`, while preserving fullscreen behavior.
- The fix is localized to the affected post and does not modify templates or site-generation logic.

### Testing
- Ran `rg -n "youtube|sandbox|referrerpolicy" blog/posts/2025-07-24-dev-workflow.md` to confirm the new attributes are present and the host is updated, which returned matching lines.
- Committed the change with `git commit -m "fix(post): harden YouTube embed privacy and iframe restrictions"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f605689c388330b921ab3b38c4bb1d)