### PR TITLE
Harden BitVM post YouTube embed privacy and iframe restrictions

### DIFF
--- a/blog/posts/2025-02-10-bitvm.md
+++ b/blog/posts/2025-02-10-bitvm.md
@@ -30,8 +30,11 @@ at [BTC++ 2025 Floripa](https://btcpp.dev/conf/floripa).
 </style>
 <div class="embed-container">
   <iframe
-    src="https://www.youtube.com/embed/gHoSpAgI7Xk"
+    src="https://www.youtube-nocookie.com/embed/gHoSpAgI7Xk"
     frameborder="0"
+    loading="lazy"
+    referrerpolicy="strict-origin-when-cross-origin"
+    sandbox="allow-scripts allow-same-origin allow-presentation"
     allowfullscreen
   ></iframe>
 </div>


### PR DESCRIPTION
### Motivation
- A third-party YouTube iframe in the BitVM post exposed readers to unnecessary tracking and unsandboxed cross-origin execution and needed minimal hardening. 
- A project-level YouTube shortcode/template was not present in the repository tree, so the fix was applied directly to the post to remove the immediate privacy regression. 

### Description
- Updated the embed `src` from `https://www.youtube.com/embed/...` to the privacy-enhanced `https://www.youtube-nocookie.com/embed/...` in `blog/posts/2025-02-10-bitvm.md`. 
- Added iframe hardening attributes `loading="lazy"`, `referrerpolicy="strict-origin-when-cross-origin"`, and `sandbox="allow-scripts allow-same-origin allow-presentation"` while keeping `allowfullscreen` and the responsive `.embed-container` wrapper unchanged. 
- The change is a minimal, single-file edit limited to `blog/posts/2025-02-10-bitvm.md` and preserves the original video functionality and layout. 

### Testing
- Ran content search with `rg -n "youtube|iframe|gHoSpAgI7Xk|youtu"` to locate the embed and verify the replacement, which succeeded. 
- Printed the edited file with `sed -n '1,140p' blog/posts/2025-02-10-bitvm.md` to confirm the new iframe attributes and `src`, which succeeded. 
- Applied the patch via a small `python` script that updated the target iframe block, and the script completed successfully. 
- Verified the resulting diff with `git diff -- blog/posts/2025-02-10-bitvm.md` to ensure only the intended lines changed, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6046a7f388330b0ece3db7991fe6d)