### PR TITLE
Harden embedded YouTube iframe privacy controls

### DIFF
--- a/blog/posts/2024-06-22-von-neumann.md
+++ b/blog/posts/2024-06-22-von-neumann.md
@@ -105,8 +105,11 @@ Below is the exact part where Wigner tells the story:
 </style>
 <div class="embed-container">
   <iframe
-    src="https://www.youtube.com/embed/HpJgBcE-cFQ?start=184"
+    src="https://www.youtube-nocookie.com/embed/HpJgBcE-cFQ?start=184"
     frameborder="0"
+    loading="lazy"
+    referrerpolicy="strict-origin-when-cross-origin"
+    sandbox="allow-scripts allow-same-origin allow-presentation"
     allowfullscreen
   ></iframe>
 </div>


### PR DESCRIPTION
### Motivation
- Reduce reader privacy and third-party script exposure from a raw YouTube iframe that previously loaded from `www.youtube.com` without containment or referrer restrictions.

### Description
- Update `blog/posts/2024-06-22-von-neumann.md` to use the privacy-enhanced host (`youtube-nocookie.com`) and add `loading="lazy"`, `referrerpolicy="strict-origin-when-cross-origin"`, and a restricted `sandbox="allow-scripts allow-same-origin allow-presentation"` attribute while preserving `allowfullscreen`.

### Testing
- No automated tests were applicable for this content-only change and no test suite updates were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6056885b88330a454e44816fbedb6)