### PR TITLE
Upgrade to Typst 0.15.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           # html export is unstable across versions; pin the exact version
           # the site is developed against
-          typst-version: "0.14.2"
+          typst-version: "0.15.0"
 
       - name: Install Pandoc
         uses: pandoc/actions/setup@86321b6dd4675f5014c611e05088e10d4939e09e # v1.1.1

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Typst
         uses: typst-community/setup-typst@63ac138db421d586de61f7f5ac3bcef6a2e6c78c # v5.1.0
         with:
-          typst-version: "0.14.2"
+          typst-version: "0.15.0"
 
       - name: Install Pandoc
         uses: pandoc/actions/setup@86321b6dd4675f5014c611e05088e10d4939e09e # v1.1.1

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ brew install watchexec
 
 > [!IMPORTANT]
 > Typst's HTML export is still unstable across versions.
-> The site is developed and CI-pinned against **Typst 0.14.2**
+> The site is developed and CI-pinned against **Typst 0.15.0**
 > and **Pandoc 3.9**.
 
 Then:

--- a/lib/template.typ
+++ b/lib/template.typ
@@ -17,7 +17,8 @@
 #let slugify(s) = lower(s).replace(" ", "-")
 
 // Show rules for HTML export: math as inline SVG frames.
-// Math would otherwise be silently dropped by typst's HTML export.
+// Typst 0.15 exports equations as MathML by default; we override to inline
+// SVG frames for pixel-consistent rendering across browsers.
 #let setup(doc) = {
   set text(lang: "en")
   show math.equation.where(block: false): it => html.elem(

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -73,9 +73,9 @@ echo "==> Collecting post metadata"
 {
   for f in "${posts[@]}"; do
     slug="$(basename "$f" .md)"
-    typst query "${TYPST_FLAGS[@]}" --input "path=/posts/$slug.md" \
+    typst eval "${TYPST_FLAGS[@]}" --input "path=/posts/$slug.md" \
       --input "body=/.cache/bodies/$slug.typ" \
-      lib/post.typ '<frontmatter>' --field value --one \
+      --in lib/post.typ 'query(<frontmatter>).first().value' \
       | jq --arg slug "$slug" '. + {slug: $slug, url: ("/posts/" + $slug + ".html")}'
   done
 } | jq -s 'sort_by(.date) | reverse' > "$CACHE/posts.json"

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -17,7 +17,7 @@ import sys
 # build.sh passes the fingerprinted stylesheet href (/css/site.<hash>.css)
 CSS_HREF = sys.argv[1] if len(sys.argv) > 1 else "/css/site.css"
 
-# Token colors of typst's built-in raw highlight theme (pinned: typst 0.14.2)
+# Token colors of typst's built-in raw highlight theme (pinned: typst 0.15.0)
 # mapped to palette-role classes defined in static/css/site.css
 TOKEN_CLASSES = {
     "#74747c": "tok-gray",  # comments

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -350,12 +350,6 @@ body > header nav {
   gap: 0.3rem 1.1rem;
 }
 
-/* typst wraps inline runs (the nav links) in a <p>; flatten it so the
-   anchors participate in the nav flex layout directly */
-body > header nav > p {
-  display: contents;
-}
-
 body > header nav a {
   font-family: var(--mono);
   font-size: 0.78rem;


### PR DESCRIPTION
Prepares the site for **Typst 0.15.0** and flips the CI pin. Opened as a
**draft** on purpose: CI will fail until `typst-community/setup-typst` can
install `0.15.0` (the release is currently `0.15.0-rc.1`). Everything below
was verified locally against the `0.15.0-rc.1` binary.

## Commits

1. **`refactor(build)`** — migrate `typst query` → `typst eval`. `query` is
   deprecated in 0.15. The new `typst eval ... --in lib/post.typ
   'query(<frontmatter>).first().value'` returns **byte-identical** metadata
   JSON across all 22 posts and removes the 22 deprecation warnings the old
   call emitted.
2. **`refactor(css)`** — drop the `body > header nav > p { display: contents }`
   flatten rule. 0.15's paragraph-grouping change no longer wraps nav links in
   a `<p>`, so the anchors are already direct flex children of `<nav>`; the
   rule is dead code and the layout is unchanged.
3. **`chore`** — bump the Typst pin (build + links workflows, README) to
   0.15.0, refresh the highlight-palette pin comment (token colours unchanged),
   and correct the math show-rule note (0.15 defaults to MathML; we keep inline
   SVG frames).

## Verification (against 0.15.0-rc.1)

- Full `scripts/build.sh` runs clean; `just check` (no data-URIs, well-formed
  atom, internal links) passes.
- Syntax highlighting intact — minification leaves `style="color: #hex"`
  values untouched, so `postprocess.py` still maps **1763** `tok-*` classes
  with **zero** unmapped colours.
- Math unchanged: all 995 SVG frames render; no `<math>` elements emitted.
- Endnote relocation and `<head>` injection still work; `<html lang="en">` is
  now emitted automatically (free a11y win).
- Nav layout confirmed visually in the browser after removing the CSS rule.

## Not done (out of scope)

- Native MathML rendering — the SVG show rule still works under 0.15; switching
  to MathML is a design decision, left for a follow-up.

## Merge gate

Hold until **Typst 0.15.0 final** ships and `setup-typst` can install it, then
CI should go green.
