### PR TITLE
ci: bump pandoc to 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Pandoc
         uses: pandoc/actions/setup@86321b6dd4675f5014c611e05088e10d4939e09e # v1.1.1
         with:
-          version: "3.9.0.2"
+          version: "3.10"
 
       - name: Build site
         run: ./scripts/build.sh

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Pandoc
         uses: pandoc/actions/setup@86321b6dd4675f5014c611e05088e10d4939e09e # v1.1.1
         with:
-          version: "3.9.0.2"
+          version: "3.10"
 
       - name: Build site
         run: ./scripts/build.sh


### PR DESCRIPTION
## What

Bump the pinned pandoc version from `3.9.0.2` to `3.10` in both CI workflows (`build.yml` and `links.yml`).

## Why

Local dev is already on pandoc 3.10, so CI was building against an older pandoc than the dev machine. This closes that drift and picks up the two typst **writer** fixes in 3.10 that affect our `pandoc --from markdown --to typst` step:

- [#11568](https://github.com/jgm/pandoc/issues/11568) — zero-width space before a span label when needed, to avoid a typst error
- [#11583](https://github.com/jgm/pandoc/issues/11583) — newline after `#set text` so following blocks (lists, etc.) parse correctly

## Notes for reviewers

- 3.10's headline typst feature, the new `--typst-input` CLI option, is **not** used here and isn't relevant: pandoc only does the `markdown → typst` text conversion in this repo and never invokes the typst binary. The `--input` values are already passed directly to `typst compile`/`typst query` in `scripts/build.sh`, which is the correct place.
- Verified locally: a full build with pandoc 3.10 (22 posts + pages + listings) runs clean (exit 0); the writer changes don't break the generated `.typ`.
- typst stays pinned at `0.14.2` (unchanged) since html export is unstable across typst versions.