### PR TITLE
build: parallelize per-file phases across cores

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ just check  # build + sanity checks (links, atom.xml, no base64 images)
 just new my-post-slug  # scaffold a new post
 ```
 
+The per-file phases (pandoc conversion, per-post compiles, listings) run in
+parallel across all cores; set `JOBS=1` to serialize, e.g. when debugging a
+single failing input.
+
 ## Layout
 
 - `posts/*.md` — blog posts (`YYYY-MM-DD-slug.md`, YAML frontmatter,

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,7 +5,9 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT="$ROOT/_site"
 CACHE="$ROOT/.cache"
-TYPST_FLAGS=(--root "$ROOT" --features html)
+# Parallelism for the independent per-file phases (override with JOBS=1 to
+# serialize, e.g. when debugging a single failing input).
+JOBS="${JOBS:-$(nproc 2>/dev/null || echo 4)}"
 
 # Compile one typst input to HTML, failing on any diagnostic other than the
 # known "html export is under active development" banner. This catches
@@ -14,7 +16,7 @@ compile() {
   local src="$1" dst="$2"
   shift 2
   local diag
-  if ! diag="$(typst compile "${TYPST_FLAGS[@]}" --format html "$@" "$src" "$dst" 2>&1)"; then
+  if ! diag="$(typst compile --root "$ROOT" --features html --format html "$@" "$src" "$dst" 2>&1)"; then
     printf 'FAIL %s\n%s\n' "$src" "$diag" >&2
     return 1
   fi
@@ -42,9 +44,72 @@ slugify() {
   printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr ' ' '-'
 }
 
+# --- per-item workers (one shell process per call, fanned out via xargs) ---
+
+# Convert a single markdown file's body to typst markup.
+convert_body() {
+  local f="$1" name
+  name="$(basename "$f" .md)"
+  pandoc "$f" --from markdown --to typst \
+    --shift-heading-level-by=-1 --wrap=none \
+    --lua-filter "$ROOT/scripts/body-filter.lua" \
+    > "$CACHE/bodies/$name.typ"
+}
+
+# Query a single post's frontmatter metadata into its own json shard.
+collect_meta() {
+  local f="$1" slug
+  slug="$(basename "$f" .md)"
+  typst eval --root "$ROOT" --features html \
+    --input "path=/posts/$slug.md" \
+    --input "body=/.cache/bodies/$slug.typ" \
+    --in lib/post.typ 'query(<frontmatter>).first().value' \
+    | jq --arg slug "$slug" '. + {slug: $slug, url: ("/posts/" + $slug + ".html")}' \
+    > "$CACHE/meta/$slug.json"
+}
+
+# Build a single post HTML page.
+build_post() {
+  local f="$1" slug
+  slug="$(basename "$f" .md)"
+  build_page "$ROOT/lib/post.typ" "$OUT/posts/$slug.html" \
+    --input "path=/posts/$slug.md" --input "body=/.cache/bodies/$slug.typ"
+}
+
+# Build a single standalone page HTML.
+build_standalone() {
+  local f="$1" name
+  name="$(basename "$f" .md)"
+  build_page "$ROOT/lib/page.typ" "$OUT/$name.html" \
+    --input "path=/pages/$name.md" --input "body=/.cache/bodies/$name.typ"
+}
+
+# Build a single listing page from a "kind[:tag]" spec.
+build_listing() {
+  local spec="$1" kind="${1%%:*}" tag="${1#*:}"
+  if [ "$kind" = tag ]; then
+    build_page "$ROOT/lib/listing.typ" "$OUT/tags/$(slugify "$tag").html" \
+      --input kind=tag --input "tag=$tag"
+  else
+    build_page "$ROOT/lib/listing.typ" "$OUT/$kind.html" --input "kind=$kind"
+  fi
+}
+
+# Run a worker function over a NUL-delimited list of items, JOBS at a time.
+# Each item becomes the single argument of one `worker` call; any failure
+# (xargs exits non-zero) aborts the build via the surrounding pipefail/set -e.
+fanout() {
+  local worker="$1"
+  xargs -0 -P "$JOBS" -I{} bash -c 'set -euo pipefail; '"$worker"' "$@"' _ {}
+}
+
+export -f compile build_page slugify convert_body collect_meta \
+  build_post build_standalone build_listing
+export ROOT OUT CACHE
+
 echo "==> Cleaning"
 rm -rf "$OUT" "$CACHE"
-mkdir -p "$OUT/posts" "$OUT/tags" "$CACHE"
+mkdir -p "$OUT/posts" "$OUT/tags" "$CACHE/bodies" "$CACHE/meta"
 
 echo "==> Copying static files"
 cp -R "$ROOT/static/." "$OUT/"
@@ -56,52 +121,30 @@ cp -R "$ROOT/static/." "$OUT/"
 CSS_HASH="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest()[:8])' "$ROOT/static/css/site.css")"
 CSS_HREF="/css/site.$CSS_HASH.css"
 cp "$OUT/css/site.css" "$OUT$CSS_HREF"
+export CSS_HREF
 
-echo "==> Converting markdown bodies with pandoc"
 shopt -s nullglob
 posts=("$ROOT"/posts/*.md)
-mkdir -p "$CACHE/bodies"
-for f in "${posts[@]}" "$ROOT"/pages/*.md; do
-  name="$(basename "$f" .md)"
-  pandoc "$f" --from markdown --to typst \
-    --shift-heading-level-by=-1 --wrap=none \
-    --lua-filter "$ROOT/scripts/body-filter.lua" \
-    > "$CACHE/bodies/$name.typ"
-done
+pages=("$ROOT"/pages/*.md)
+
+echo "==> Converting markdown bodies with pandoc"
+printf '%s\0' "${posts[@]}" "${pages[@]}" | fanout convert_body
 
 echo "==> Collecting post metadata"
-{
-  for f in "${posts[@]}"; do
-    slug="$(basename "$f" .md)"
-    typst eval "${TYPST_FLAGS[@]}" --input "path=/posts/$slug.md" \
-      --input "body=/.cache/bodies/$slug.typ" \
-      --in lib/post.typ 'query(<frontmatter>).first().value' \
-      | jq --arg slug "$slug" '. + {slug: $slug, url: ("/posts/" + $slug + ".html")}'
-  done
-} | jq -s 'sort_by(.date) | reverse' > "$CACHE/posts.json"
+printf '%s\0' "${posts[@]}" | fanout collect_meta
+jq -s 'sort_by(.date) | reverse' "$CACHE"/meta/*.json > "$CACHE/posts.json"
 
 echo "==> Building posts ($(jq length "$CACHE/posts.json"))"
-for f in "${posts[@]}"; do
-  slug="$(basename "$f" .md)"
-  build_page "$ROOT/lib/post.typ" "$OUT/posts/$slug.html" \
-    --input "path=/posts/$slug.md" --input "body=/.cache/bodies/$slug.typ"
-done
+printf '%s\0' "${posts[@]}" | fanout build_post
 
 echo "==> Building pages"
-for f in "$ROOT"/pages/*.md; do
-  name="$(basename "$f" .md)"
-  build_page "$ROOT/lib/page.typ" "$OUT/$name.html" \
-    --input "path=/pages/$name.md" --input "body=/.cache/bodies/$name.typ"
-done
+printf '%s\0' "${pages[@]}" | fanout build_standalone
 
 echo "==> Building listings"
-build_page "$ROOT/lib/listing.typ" "$OUT/index.html" --input kind=index
-build_page "$ROOT/lib/listing.typ" "$OUT/archive.html" --input kind=archive
-while IFS= read -r tag; do
-  [ -n "$tag" ] || continue
-  build_page "$ROOT/lib/listing.typ" "$OUT/tags/$(slugify "$tag").html" \
-    --input kind=tag --input "tag=$tag"
-done < <(jq -r '[.[].tags[]] | unique | .[]' "$CACHE/posts.json")
+{
+  printf 'index\0archive\0'
+  jq -r '[.[].tags[]] | unique | .[] | "tag:" + .' "$CACHE/posts.json" | tr '\n' '\0'
+} | fanout build_listing
 
 echo "==> Checking for silently escaped raw HTML"
 # cmarker only parses raw HTML tags written on a single line; multi-line


### PR DESCRIPTION
The build spawned ~72 serial typst processes (22 frontmatter evals +
22 post compiles + 3 pages + 25 listings), each paying a full typst
startup and font load. Wall time was dominated by process startup, not
work, while the CI runner's cores sat idle.

Refactor each independent per-file loop (pandoc body conversion,
frontmatter metadata, posts, pages, listings) into a worker function
fanned out with `xargs -P $(nproc)`. Metadata now lands in per-post JSON
shards merged with one `jq -s`, so parallel writers never interleave.
Output is byte-for-byte identical to the previous serial build; failures
still abort via pipefail + `set -e` (xargs exits non-zero on any child
failure). `JOBS=1` restores serial behaviour for debugging.

Measured locally (22 posts, 4 cores): 9.4s -> 2.8s (~3.4x).

Evaluated Typst 0.15's experimental bundle export (`--features bundle`)
as an alternative: it works (one invocation emits every page, ToC
`outline()` scopes correctly per document, metadata matches), but a
single bundle process can't saturate multiple cores and measured slower
here (3.9s) than the parallel many-process build. It also rides an
unstable in-development flag and changes output (MathML <style> on every
page, auto ids on all headings). Not adopted; revisit if it stabilizes.