### PR TITLE
ci: add ShellCheck workflow and fix lint warning

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,24 @@
+name: ShellCheck
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  shellcheck:
+    name: Lint shell scripts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # shellcheck ships preinstalled on GitHub-hosted ubuntu runners, so no
+      # extra action or dependency to pin.
+      - name: Run ShellCheck
+        run: shellcheck scripts/*.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -86,7 +86,7 @@ build_standalone() {
 
 # Build a single listing page from a "kind[:tag]" spec.
 build_listing() {
-  local spec="$1" kind="${1%%:*}" tag="${1#*:}"
+  local kind="${1%%:*}" tag="${1#*:}"
   if [ "$kind" = tag ]; then
     build_page "$ROOT/lib/listing.typ" "$OUT/tags/$(slugify "$tag").html" \
       --input kind=tag --input "tag=$tag"


### PR DESCRIPTION
Add a ShellCheck CI job that lints the repo's shell scripts on push, PR,
and manual dispatch. shellcheck is preinstalled on GitHub-hosted ubuntu
runners, so no third-party action or dependency needs pinning, keeping
in line with the repo's locked-down workflow style (permissions: {},
persist-credentials: false).

Also fix the one warning it surfaced: drop the unused `spec` local in
build.sh's build_listing (kind/tag are derived from $1 directly).