### PR TITLE
Fix block-math alignment on mobile

### DIFF
--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -4,7 +4,10 @@
    replacing it with a custom <html> element would break native footnotes).
 2. Move the endnotes section, which typst appends at the very end of <body>,
    back inside <main> so it sits above the site footer.
-3. Rewrite syntax-highlight colors (inline styles from typst's built-in
+3. Wrap block equations in a <div class="math-block"> scroll container so wide
+   math scrolls instead of overflowing the column — the overflow must live on
+   a wrapper, not the <math> element (see site.css for why).
+4. Rewrite syntax-highlight colors (inline styles from typst's built-in
    default raw theme) into .tok-* classes so CSS can swap the palette per
    color scheme. Any color span left unmapped fails the build loudly: it
    means a typst upgrade changed the default theme's palette and this
@@ -48,6 +51,10 @@ HEAD = (
 
 ENDNOTES = re.compile(r"[ \t]*<section role=\"doc-endnotes\">.*?</section>\n?", re.S)
 
+# Block equations only (display="block"); inline <math> is left alone. <math>
+# never nests, so the first </math> closes the match.
+BLOCK_MATH = re.compile(r'<math\b[^>]*\bdisplay="block"[^>]*>.*?</math>', re.S)
+
 html = sys.stdin.read()
 
 if "</head>" not in html:
@@ -59,6 +66,10 @@ if match:
     html = ENDNOTES.sub("", html, count=1)
     notes = match.group(0).rstrip("\n")
     html = html.replace("</main>", notes + "\n</main>", 1)
+
+html = BLOCK_MATH.sub(
+    lambda m: '<div class="math-block">' + m.group(0) + "</div>", html
+)
 
 for hex_color, cls in TOKEN_CLASSES.items():
     html = html.replace(f'<span style="color: {hex_color}">', f'<span class="{cls}">')

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -582,14 +582,23 @@ h3.tag-heading a.tag {
 
 /* MathML is live text: it inherits `color`, so light/dark mode works with no
    repainting, and it scales with zoom/font-size. Inline math needs no styling
-   (native baseline alignment). Block math is centered, and wide equations
-   scroll horizontally instead of overflowing the column. */
-math[display="block"] {
-  display: block;
-  width: fit-content;
-  max-width: 100%;
-  margin: 1.8rem auto;
+   (native baseline alignment). Block math is centered by the engine's default
+   display-equation layout, and wide equations scroll horizontally instead of
+   overflowing the column.
+
+   The horizontal scroll lives on a wrapper (postprocess.py wraps each block
+   equation in <div class="math-block">), never on the <math> element itself:
+   giving <math> an intrinsic width (fit-content) or overflow makes engines
+   collapse it to min-content — every atom stacking vertically on a narrow
+   screen — or right-align it (iOS Safari). Left untouched, <math> stays a
+   full-width centered block, and the wrapper scrolls when it is too wide. */
+.math-block {
+  margin: 1.8rem 0;
   overflow-x: auto;
+}
+
+math[display="block"] {
+  margin: 0;
 }
 
 /* --- Code --------------------------------------------------------------------------------- */


### PR DESCRIPTION
Block equations were right-aligned (and on Chromium, collapsed to
min-content with atoms stacking vertically) on narrow screens. The cause
was putting an intrinsic width (width: fit-content) and overflow-x on the
<math> element itself: engines mis-size MathML when it is given an
intrinsic width or made a scroll container.

Move the horizontal scroll to a wrapper instead. postprocess.py now wraps
each block equation in <div class="math-block">, which owns the
overflow-x: auto and vertical margins; the <math> element is left at its
default full-width display-equation layout, which the browser centers.
Wide equations now scroll from the left inside the wrapper; equations that
fit are centered. Inline math is untouched.