### PR TITLE
Fix raw Typst passthrough in Markdown build

### DIFF
--- a/scripts/body-filter.lua
+++ b/scripts/body-filter.lua
@@ -10,6 +10,9 @@ Pandoc Lua filter: markdown -> typst body for storopoli.com.
 - Raw HTML: typst has no raw-HTML primitive, so the known patterns are
   mapped to template helpers; anything unrecognized fails the build
   loudly rather than disappearing.
+- Other raw formats: reject explicitly. In particular, Pandoc raw Typst
+  blocks/inlines would otherwise survive conversion and be eval()ed by
+  the templates, bypassing the raw-HTML allowlist.
 ]]
 
 local function typst_str(s)
@@ -86,9 +89,15 @@ local function html_to_typst(html)
   return nil
 end
 
+local function reject_raw(el, kind)
+  io.stderr:write('body-filter.lua: unhandled raw ' .. kind .. ' format '
+    .. el.format .. ': ' .. el.text:sub(1, 120) .. '\n')
+  os.exit(1)
+end
+
 function RawBlock(el)
   if el.format ~= 'html' then
-    return nil
+    reject_raw(el, 'block')
   end
   local typst = html_to_typst(el.text)
   if typst == nil then
@@ -101,7 +110,7 @@ end
 
 function RawInline(el)
   if el.format ~= 'html' then
-    return nil
+    reject_raw(el, 'inline')
   end
   local typst = html_to_typst(el.text)
   if typst == nil then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -50,7 +50,7 @@ slugify() {
 convert_body() {
   local f="$1" name
   name="$(basename "$f" .md)"
-  pandoc "$f" --from markdown --to typst \
+  pandoc "$f" --from markdown-raw_attribute --to typst \
     --shift-heading-level-by=-1 --wrap=none \
     --lua-filter "$ROOT/scripts/body-filter.lua" \
     > "$CACHE/bodies/$name.typ"


### PR DESCRIPTION
### Motivation

- The Markdown -> Typst pipeline converted posts into Typst and `eval()`ed the generated bodies, which allowed Pandoc raw Typst blocks (e.g. fenced ``{=typst}``) to survive conversion and be executed, enabling first-party HTML/script emission from content.
- The change aims to close this bypass by preventing non-HTML raw Pandoc elements from passing through into evaluated Typst markup.

### Description

- Stop accepting Pandoc raw attributes during conversion by changing the reader from `markdown` to `markdown-raw_attribute` in `scripts/build.sh`, which prevents `{=typst}` raw blocks/inlines from being parsed and propagated.
- Make the Pandoc Lua filter `scripts/body-filter.lua` fail closed on any non-HTML raw element by adding a `reject_raw` helper and exiting when `RawBlock`/`RawInline` elements are not `format == 'html'`, instead of returning `nil` and leaving them unchanged.
- Preserve the existing allowlist and mapping for known-safe raw HTML patterns (YouTube iframe -> `youtube()`, standalone `<img>` -> `raw-img`, `<br>`, comments, etc.) in `scripts/body-filter.lua` so existing safe embeds keep working.

### Testing

- Ran a syntax check with `bash -n scripts/build.sh`, which succeeded. 
- Ran `git diff --check`, which reported no whitespace or diff issues. 
- Searched the tree for indicators of the original bypass with `rg -n '\{=typst\}|raw_attribute|Raw(Block|Inline)|html\.elem|<script|on[a-z]+='`, which executed and returned expected locations. 
- Attempted a full build with `./scripts/build.sh`, which could not complete in this environment due to `pandoc` not being installed (`pandoc: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48c0eb20c08330b3e38a7c702940e3)