### PR TITLE
fix: repair broken links and exclude flaky hosts from lychee

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -17,6 +17,12 @@ exclude = [
   "^https://smp12\\.simplex\\.im/",
   "^https://crates\\.io/",
   "^https://www\\.urbandictionary\\.com/",
+  # diagram renderer; intermittently 503 rate-limits
+  "^https://mermaid\\.ink/",
+  # rate-limits link checkers, causes timeouts
+  "^https://www\\.gnu\\.org/",
+  # HTTP/2 protocol errors against lychee's client
+  "^https://polymarket\\.com/",
 ]
 
 exclude_path = []

--- a/posts/2024-01-30-sudoku.md
+++ b/posts/2024-01-30-sudoku.md
@@ -93,7 +93,7 @@ This is a great advantage, since you don't have to ask for permissions to Google
 [Tim Apple](https://youtu.be/XHVxm12NbrY).
 
 **In Dioxus making a PWA was really easy**.
-There is a PWA template in the [`examples/` directory in their repository](https://github.com/DioxusLabs/dioxus/tree/main/examples/pwa).
+There is a PWA template in the [`examples/` directory in their repository](https://github.com/DioxusLabs/dioxus/tree/v0.6.3/examples/pwa).
 You just have to follow the instructions in the README and you're done.
 In my case, I only had to change the metadata in the `manifest.json` file
 and add what I wanted to cache in the service worker `.js` file.

--- a/posts/2024-03-23-dead-man-switch.md
+++ b/posts/2024-03-23-dead-man-switch.md
@@ -59,7 +59,7 @@ My inspiration to build one came from two sources.
 First, a friend of mine told me that he is using a bunch of badly-written
 shell scripts with some cron jobs to manage his DMS.
 Second, there might be a genuine need for a simple DMS in the privacy community.
-For example, [finalmessage.io](https://finalmessage.io),
+For example, [finalmessage.io](https://web.archive.org/web/20260218185104/https://finalmessage.io/),
 despite being closed source, and you have no idea who's behind it,
 has gathered enough users in a subscription model and they are not accepting new
 users anymore.

--- a/posts/2025-02-10-bitvm.md
+++ b/posts/2025-02-10-bitvm.md
@@ -8,7 +8,7 @@ bib: true
 ---
 
 This post is the written version of my very condensed 45-minute talk
-at [BTC++ 2025 Floripa](https://btcpp.dev/conf/floripa).
+at BTC++ 2025 Floripa.
 
 <div class="embed-container">
   <iframe src="https://www.youtube-nocookie.com/embed/gHoSpAgI7Xk" frameborder="0" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" sandbox="allow-scripts allow-same-origin allow-presentation" allowfullscreen></iframe>


### PR DESCRIPTION
Fixes the 7 link-checker failures from CI run 29248658850.

## What changed

- **Dioxus PWA example (404)**: pinned to the `v0.6.3` tag — the example was removed from `main` but still exists there (verified 200).
- **finalmessage.io (530)**: the service is dead; the link now points to the Wayback Machine snapshot from Feb 2026.
- **btcpp.dev/conf/floripa (timeout)**: the site hangs on every request; removed the hyperlink, keeping "BTC++ 2025 Floripa" as plain text.
- **lychee.toml excludes**: added `mermaid.ink` (intermittent 503 rate-limits), `www.gnu.org` (rate-limits link checkers, causes timeouts), and `polymarket.com` (HTTP/2 protocol errors against lychee's client). All three targets are alive — the failures are checker-side.

## Notes for review

- The Wayback URL returns 429 under rapid probing, but the config already accepts 429 and the snapshot existence was confirmed via the archive.org availability API.
- lychee wasn't available locally; replacement URLs were verified with curl. CI on this branch is the definitive check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)